### PR TITLE
Don't add domain to fqdn

### DIFF
--- a/templates/etc/hosts.j2
+++ b/templates/etc/hosts.j2
@@ -41,7 +41,7 @@
 {%   for host in play_hosts %}
 {%     if (hostvars[host]['ansible_domain'] == etc_hosts_pri_dns_name) or hostvars[host]['ansible_domain'] == '' %}
 {%       if etc_hosts_use_default_ip_address and not etc_hosts_use_ansible_ssh_host %}
-{{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['ansible_fqdn'] }}.{{ etc_hosts_pri_dns_name }} {{ hostvars[host]['ansible_hostname'] }}
+{{ hostvars[host]['ansible_default_ipv4']['address'] }} {{ hostvars[host]['ansible_fqdn'] }} {{ hostvars[host]['ansible_hostname'] }}
 {%       elif not etc_hosts_use_default_ip_address and etc_hosts_use_ansible_ssh_host %}
 {%         if hostvars[host]['ansible_fqdn'] != (hostvars[host]['ansible_hostname']+ '.' + etc_hosts_pri_dns_name) %}
 {%           if hostvars[host]['ansible_ssh_host'] is defined %}


### PR DESCRIPTION
remove .{{ etc_hosts_pri_dns_name }} from template when using fqdn

alternate would be to use: {{ hostvars[host]['ansible_hostname'] }}.{{ etc_hosts_pri_dns_name }}

I'm new to all this so I can't really eval which is correct/better, or if in some way lxd's behavior is unique and needs a config var to branch on.

Resolves issue #6